### PR TITLE
Update concat_filter.rb to allow deeper folders

### DIFF
--- a/lib/concat_filter.rb
+++ b/lib/concat_filter.rb
@@ -25,7 +25,7 @@ class ConcatFilter < Nanoc3::Filter
   identifier :concat
 
   def run(content, args = {})
-    content.gsub(%r{^\s*(?:(?://|#) require |@import url)\(?([a-zA-Z0-9_\-\.]+)(?:\);)?$}) do |m|
+    content.gsub(%r{^\s*(?:(?://|#) require |@import url)\(?([a-zA-Z0-9_\-\./]+)(?:\);)?$}) do |m|
       load_file($1) || m
     end
   end


### PR DESCRIPTION
Just a single character "/" in the regex to allow the filter to
include .js files below the level of the enveloping file - eg
`// require plugins/minimap.js`
