### PR TITLE
Force UTF-8 encoding for data source

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -127,3 +127,6 @@ data_sources:
     # The path where layouts should be mounted. The layouts root behaves the
     # same as the items root, but applies to layouts rather than items.
     layouts_root: /
+
+    # Force encoding to be UTF-8. 
+    encoding: 'UTF-8'


### PR DESCRIPTION
My Ruby installation defaults to US-ASCII (apparently). That makes `nanoc compile` throw an exception, because the files in this template contain UTF-8 (which is cool!). 

After manually setting the encoding for the data source to UTF-8, this issue was solved.

I'm not 100% sure whether this should be part of the template, or actually should be considered to be an error in my Ruby installation.
