### PR TITLE
Make the meta_tag function escape HTML

### DIFF
--- a/lib/default.rb
+++ b/lib/default.rb
@@ -1,5 +1,6 @@
 require "bundler/setup"
 require 'nanoc/cachebuster'
+require 'erb'
 include Nanoc::Helpers::CacheBusting
 include Nanoc::Helpers::XMLSitemap
 include Nanoc::Helpers::Rendering
@@ -9,6 +10,7 @@ include Nanoc::Helpers::Filtering
 include Nanoc::Helpers::Tagging
 include Nanoc::Helpers::Capturing
 include Nanoc::Helpers::Text
+include ERB::Util
 
 # Output a meta-tag for use in your site header. The key you supply is looked
 # up in the configuration under 'meta_data'. You can override it on a per-item
@@ -26,5 +28,5 @@ include Nanoc::Helpers::Text
 # @site.config[:keywords].
 def meta_tag(key)
   value = @item[key] || @site.config[:meta_data][key]
-  '<meta name="%s" content="%s">' % [key, value] if value
+  '<meta name="%s" content="%s">' % [h(key), h(value)] if value
 end


### PR DESCRIPTION
The meta_tag function did not properly escape HTML. This patch fixes this.
